### PR TITLE
Enabling sync

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -86,7 +86,7 @@ def MainMenu():
 
 	return oc
 
-@route('/video/giantbomb/erun')
+@route('/video/giantbomb/erun', allow_sync=True)
 def EnduranceRunMenu():
 	oc = ObjectContainer(
 		objects = [
@@ -135,7 +135,7 @@ def EnduranceRunMenu():
 
 	return oc
 
-@route('/video/giantbomb/videos')
+@route('/video/giantbomb/videos', allow_sync=True)
 def Videos(cat_id=None, query=None, offset=0):
 	oc = ObjectContainer()
 


### PR DESCRIPTION
Adding the `allow_sync` flag should enable downloading/syncing items to watch offline.